### PR TITLE
Сетевое взаимодействие Pod, сервисы

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,28 @@
+# Выполнено ДЗ №3
+
+ - [x] Основное ДЗ
+ - [ ] Задание со *
+
+## В процессе сделано:
+ - Изменена readiness-проба в манифесте deployment.yaml из прошлого ДЗ на httpGet, вызывающую URL /index.html
+ - Создан манифест service.yaml, описывающий сервис типа ClusterIP, который направляет трафик на поды, управляемые deployment
+ - Установлен ingress-контроллер nginx
+ - Создан манифест ingress.yaml, в котором описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис.
+
+## Как запустить проект:
+ - `minikube start --driver=docker`
+ - `minikube addons enable ingress`
+ - `kubectl apply -f namespace.yaml`
+ - `kubectl label nodes minikube homework=true`
+ - `kubectl apply -f deployment.yaml`
+ - `kubectl apply -f service.yaml`
+ - `kubectl apply -f ingress.yaml`
+
+
+## Как проверить работоспособность:
+ - `echo "$(minikube ip) homework.otus" >> /etc/hosts`
+ - `curl http://homework.otus/index.html`
+
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания
+

--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework
+  labels:
+    name: nginx
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          command: ["/bin/sh","-c"]
+          args: ["sed -i 's/listen .*/listen 8000;/g ; s,root .*,root /homework;,g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+          ports:
+          - containerPort: 8000
+          volumeMounts:
+          - name: workdir
+            mountPath: "/homework"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["rm", "-f", "/homework/index.html"]
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      initContainers:
+        - name: install
+          image: busybox:1.28
+          command: ["wget", "-O", "/init/index.html", "http://info.cern.ch"]
+          volumeMounts:
+          - name: workdir
+            mountPath: "/init"
+      dnsPolicy: Default
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      nodeSelector:
+        homework: "true"
+

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-hw3
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+  - host: "homework.otus"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: svc-hw3
+            port:
+              number: 80
+

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-hw3
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Изменена readiness-проба в манифесте deployment.yaml из прошлого ДЗ на httpGet, вызывающую URL /index.html
 - Создан манифест service.yaml, описывающий сервис типа ClusterIP, который направляет трафик на поды, управляемые deployment
 - Установлен ingress-контроллер nginx
 - Создан манифест ingress.yaml, в котором описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис.

## Как запустить проект:
 - `minikube start --driver=docker`
 - `minikube addons enable ingress`
 - `kubectl apply -f namespace.yaml`
 - `kubectl label nodes minikube homework=true`
 - `kubectl apply -f deployment.yaml`
 - `kubectl apply -f service.yaml`
 - `kubectl apply -f ingress.yaml`


## Как проверить работоспособность:
 - `echo "$(minikube ip) homework.otus" >> /etc/hosts`
 - `curl http://homework.otus/index.html`

## PR checklist:
 - [*] Выставлен label с темой домашнего задания