### PR TITLE
Volumes, StorageClass, PV, PVC

### DIFF
--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,28 @@
+# Выполнено ДЗ №4
+
+ - [*] Основное ДЗ
+
+## В процессе сделано:
+ - Создан манифест pvc.yaml, описывающий PersistentVolumeClaim, запрашивающий хранилище с storageClass по-умолчанию
+ - Создан манифест cm.yaml для объекта типа configMap
+ - В манифесте deployment.yaml изменена спецификация volume типа emptyDir, который монтируется в init и основной контейнер, на pvc, созданный в предыдущем пункте
+ - В манифесте deployment.yaml добавлено монтирование ранее созданного configMap как volume к основному контейнеру пода в директорию /homework/conf, так, чтобы его содержимое можно было получить, обратившись по url /conf/file
+
+
+## Как запустить проект:
+ - `minikube start --driver=docker`
+ - `kubectl apply -f namespace.yaml`
+ - `kubectl label nodes minikube homework=true`
+ - `kubectl apply -f cm.yaml`
+ - `kubectl apply -f pvc.yaml`
+ - `kubectl apply -f deployment.yaml`
+ - `kubectl apply -f service.yaml`
+ - `kubectl apply -f ingress.yaml`
+
+## Как проверить работоспособность:
+ - `curl http://homework.otus/conf/file`
+ - `curl http://homework.otus/`
+
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания
+

--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-hw4
+  namespace: homework
+data:
+  file: |
+    key1=value1
+    key2=value2
+    key3=value3
+    key4=value4
+

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework
+  labels:
+    name: nginx
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          command: ["/bin/sh","-c"]
+          args: ["sed -i 's/listen .*/listen 8000;/g ; s,root .*,root /homework;,g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+          ports:
+          - containerPort: 8000
+          volumeMounts:
+          - name: pv-hw4
+            mountPath: "/homework"
+          - name: configmap-hw4
+            mountPath: "/homework/conf"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["rm", "-f", "/homework/index.html"]
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      initContainers:
+        - name: install
+          image: busybox:1.28
+          command: ["wget", "-O", "/init/index.html", "http://info.cern.ch"]
+          volumeMounts:
+          - name: pv-hw4
+            mountPath: "/init"
+      dnsPolicy: Default
+      volumes:
+      - name: pv-hw4
+        persistentVolumeClaim:
+          claimName: pvc-hw4
+      - name: configmap-hw4
+        configMap:
+          name: cm-hw4
+          items:
+            - key: file
+              path: file
+      nodeSelector:
+        homework: "true"
+

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-hw3
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+  - host: "homework.otus"
+    http:
+      paths:
+      - path: /(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: svc-hw3
+            port:
+              number: 80
+

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-hw4
+  namespace: homework
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-hw3
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [*] Основное ДЗ

## В процессе сделано:
 - Создан манифест pvc.yaml, описывающий PersistentVolumeClaim, запрашивающий хранилище с storageClass по-умолчанию
 - Создан манифест cm.yaml для объекта типа configMap
 - В манифесте deployment.yaml изменена спецификация volume типа emptyDir, который монтируется в init и основной контейнер, на pvc, созданный в предыдущем пункте
 - В манифесте deployment.yaml добавлено монтирование ранее созданного configMap как volume к основному контейнеру пода в директорию /homework/conf, так, чтобы его содержимое можно было получить, обратившись по url /conf/file


## Как запустить проект:
 - minikube start --driver=docker
 - kubectl apply -f namespace.yaml
 -  kubectl label nodes minikube homework=true
 -  kubectl apply -f cm.yaml
 -  kubectl apply -f pvc.yaml
 -  kubectl apply -f deployment.yaml
 -  kubectl apply -f service.yaml
 -  kubectl apply -f ingress.yaml

## Как проверить работоспособность:
 - curl http://homework.otus/conf/file
 - curl http://homework.otus/

## PR checklist:
 - [*] Выставлен label с темой домашнего задания
