### PR TITLE
Создание собственного CRD

### DIFF
--- a/kubernetes-operators/README.md
+++ b/kubernetes-operators/README.md
@@ -1,0 +1,25 @@
+# Выполнено ДЗ №7
+
+ - [x] Основное ДЗ
+ - [ ] Задание со *
+
+## В процессе сделано:
+ - Создан манифест CustomResourceDefinition (crd.yaml)
+ - Созданы манифесты ServiceAccount, ClusterRole и ClusterRoleBinding (sa-cr-crb.yaml)
+ - Создан манифест deployement для оператора (operator.yaml)
+ - Создан манифест CustomResource kind: MySQL (cr.yaml)
+ - Приложен вывод команды `kubectl get pvc,pv,svc,deploy,pods,mysqls,sa > resources.txt`
+
+## Как запустить проект:
+  `kubectl apply -f crd.yaml -f sa-cr-crb.yaml -f operator.yaml`
+  `kubectl apply -f cr.yaml`
+
+## Как проверить работоспособность:
+ - Обеспечить доступ к развернутому MySQL
+   `kubectl --namespace monitoring port-forward service/mysql-cr-hw7 3306:3306`
+ - Попытаться подключиться при помощи консольного клиента и убедиться, что подключение отбито с ошибкой "ERROR 1045 (28000): Access denied"
+   `mysql -h 127.1`
+
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания
+

--- a/kubernetes-operators/cr.yaml
+++ b/kubernetes-operators/cr.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-cr-hw7
+spec:
+  image: mysql
+  database: testdb
+  password: secret
+  storage_size: 1Gi
+

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  group: otus.homework
+  scope: Namespaced
+  names:
+    kind: MySQL
+    plural: mysqls
+    singular: mysql
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            status:
+              type: object
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size
+

--- a/kubernetes-operators/operator.yaml
+++ b/kubernetes-operators/operator.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-hw7
+  labels:
+    name: mysql-op-hw7
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-op-hw7
+  template:
+    metadata:
+      labels:
+        app: mysql-op-hw7
+    spec:
+      containers:
+        - name: mysql-operator-hw7
+          image: roflmaoinmysoul/mysql-operator:1.0.0
+          imagePullPolicy: Always
+      serviceAccountName: sa-hw7
+

--- a/kubernetes-operators/resources.txt
+++ b/kubernetes-operators/resources.txt
@@ -1,0 +1,22 @@
+NAME                                     STATUS   VOLUME            CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+persistentvolumeclaim/mysql-cr-hw7-pvc   Bound    mysql-cr-hw7-pv   1Gi        RWO            standard       4m59s
+
+NAME                               CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                      STORAGECLASS   REASON   AGE
+persistentvolume/mysql-cr-hw7-pv   1Gi        RWO            Retain           Bound    default/mysql-cr-hw7-pvc   standard                4m59s
+
+NAME                   TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+service/kubernetes     ClusterIP   10.96.0.1    <none>        443/TCP    105d
+service/mysql-cr-hw7   ClusterIP   None         <none>        3306/TCP   4m59s
+
+NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/mysql-cr-hw7   1/1     1            1           4m59s
+
+NAME                                READY   STATUS    RESTARTS   AGE
+pod/mysql-cr-hw7-557db85fb4-h6v85   1/1     Running   0          4m59s
+
+NAME                               AGE
+mysql.otus.homework/mysql-cr-hw7   4m59s
+
+NAME                     SECRETS   AGE
+serviceaccount/default   0         105d
+serviceaccount/sa-hw7    0         6m34s

--- a/kubernetes-operators/sa-cr-crb.yml
+++ b/kubernetes-operators/sa-cr-crb.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-hw7
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crole-hw7
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-hw7
+roleRef:
+  kind: ClusterRole
+  name: crole-hw7
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sa-hw7
+  namespace: default
+


### PR DESCRIPTION
# Выполнено ДЗ №7

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Создан манифест CustomResourceDefinition (crd.yaml)
 - Созданы манифесты ServiceAccount, ClusterRole и ClusterRoleBinding (sa-cr-crb.yaml)
 - Создан манифест deployement для оператора (operator.yaml)
 - Создан манифест CustomResource kind: MySQL (cr.yaml)
 - Приложен вывод команды `kubectl get pvc,pv,svc,deploy,pods,mysqls,sa > resources.txt`
 - Проверка показала, что после удаления кастомного ресурса не удаляется PV (status: Released)

## Как запустить проект:
  `kubectl apply -f crd.yaml -f sa-cr-crb.yaml -f operator.yaml`
  `kubectl apply -f cr.yaml`

## Как проверить работоспособность:
 - Обеспечить доступ к развернутому MySQL
   `kubectl --namespace monitoring port-forward service/mysql-cr-hw7 3306:3306`
 - Попытаться подключиться при помощи консольного клиента и убедиться, что подключение отбито с ошибкой "ERROR 1045 (28000): Access denied"
   `mysql -h 127.1`

## PR checklist:
 - [*] Выставлен label с темой домашнего задания